### PR TITLE
Corrects URL for icon

### DIFF
--- a/platform/kots-app.yaml
+++ b/platform/kots-app.yaml
@@ -5,7 +5,7 @@ metadata:
   name: moxie
 spec:
   title: moxie
-  icon: https://github.com/ossf/artwork/blob/70c1012bf5f2a97cdf5335f041f087a74150b7e5/openssf/icon/color/openssf-icon-color.png
+  icon: https://raw.githubusercontent.com/ossf/artwork/master/openssf/icon/color/openssf-icon-color.png
   statusInformers: 
   - cert-manager/deployment/cert-manager
   ports: []


### PR DESCRIPTION
TL;DR
-----

Uses the proper URL for the application icon

Details
-------

Specifies the correct GitHub raw URL for the OpenSSF icon.
