### PR TITLE
Updates SANs for Spire certificate

### DIFF
--- a/platform/spire/certificate.yaml
+++ b/platform/spire/certificate.yaml
@@ -11,8 +11,8 @@ spec:
   renewBefore: 168h  #  7 days
   dnsNames:
     - spire-oidc.spire.svc.cluster.local
-    - '{{repl list "oidc" (ConfigOption "subdomain") | join "." }}'
-    - oidc
+    - '{{repl list "spire" (ConfigOption "subdomain") | join "." }}'
+    - spire
   privateKey:
     algorithm: ECDSA
     size: 256


### PR DESCRIPTION
TL;DR
-----

Realigns cert to expected hostnames for Spire

Details
-------

Corrects the SANs in the Spire certificate to match changes in the
Spire configuration. Instead of \`oidc\` the hostname for accessing
Spire is now \`spire\`, and the certificates were using the old name.
